### PR TITLE
Add MathJax.js to the article and blog templates.

### DIFF
--- a/src/blog/posts/2016-06-29 darktable colour checker lut module/index.md
+++ b/src/blog/posts/2016-06-29 darktable colour checker lut module/index.md
@@ -1,12 +1,12 @@
 ---
-date: 2016-06-29T08:44:08-05:00 
+date: 2016-06-29T08:44:08-05:00
 title: Color Manipulation with the Colour Checker LUT Module
 sub-title: hanatos tinkering in darktable again...
 
 lede-img: darktable-lut-lede.jpg
 lede-img-thumb: th_darktable-lut-lede.jpg
-lede-attribution: 
-lede-style: 
+lede-attribution:
+lede-style:
 
 author: Johannes Hanika
 author-img: /images/authors/johannes_hanika.jpg
@@ -436,7 +436,3 @@ calibration though.
 * <a title="calibrate vignetting for lensfun" href="http://wilson.bronger.org/lens_calibration_tutorial/#id3">lensfun calibration</a>
 * <a title="perspective correction in darktable" href="http://www.darktable.org/2016/03/a-new-module-for-automatic-perspective-correction/">perspective correction in darktable</a>
 * <a title="fit basecurves for darktable" href="http://www.darktable.org/2013/10/about-basecurves/">fit basecurves for darktable</a>
-
-
-
-<script type='text/javascript' src='MathJax.js'></script>

--- a/templates/article.hbt
+++ b/templates/article.hbt
@@ -45,12 +45,12 @@
     <link rel="stylesheet" href="/styles/prism.css"/>
 
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
-    
+
 
     {{#if stylesheet}}<link rel="stylesheet" href="{{stylesheet}}"/>{{/if}}
-    
+
     <meta name="viewport" content="width=device-width, initial-scale=1">
-	
+
 	<style type="text/css" media="all">
 		{{#if lede-img}} #lede { background-image: url('{{{ lede-img }}}'); } {{/if}}
 		{{#if lede-style}} #lede { {{ lede-style }} } {{/if}}
@@ -87,7 +87,7 @@
                         <!-- Begin article content -->
                             <h1 id="title">{{ title }}</h1>
                             {{#if sub-title}} <p id="subtitle">{{ sub-title }}</p> {{/if}}
-                            {{!-- 
+                            {{!--
                             {{#if author}} <p class="author-name">{{ author }}</p> {{/if}}
                             {{#if date}} <p class="article-date">{{{niceDate date}}}</p> {{/if}}
                             --}}
@@ -115,7 +115,7 @@
                     {{/is_even}}
                 {{/each}}
 
-                
+
                 <!-- End article content -->
             </div>
 
@@ -132,7 +132,7 @@
                             {{/if}}
                             <div class="author-box-info">
                                 {{! should link to page of authors posts }}
-                                <div class="author-name">{{#if author}} 
+                                <div class="author-name">{{#if author}}
                                     {{#if author-url}}
                                     <a href="{{ author-url}}" title="{{ author }}" rel="author">{{ author }}</a>
                                     {{ else }}
@@ -141,7 +141,7 @@
                                 {{/if}}</div>
                                 {{#if author-email}} <div class="author-email"> {{ author-email }} </div> {{/if}}
                                 {{#if author-bio}} <div class="author-bio"> {{{ author-bio }}} </div> {{/if}}
-                            </div> 
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -205,7 +205,7 @@
             {{>footer}}
 
         </div>
-
+				<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
         <script src="/js/window-scroll.js"></script>
         <script src="/js/push-menu.js"></script>
         <script src="/js/prism.js"></script>
@@ -213,4 +213,3 @@
 		<script src="/js/img-swap.js"></script>
 	</body>
 </html>
-

--- a/templates/blog-posts.hbt
+++ b/templates/blog-posts.hbt
@@ -197,10 +197,10 @@
             {{>footer}}
 
         </div>
-
+				<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
         <script src="/js/window-scroll.js"></script>
         <script src="/js/push-menu.js"></script>
-		<script src="/js/img-swap.js"></script>
+				<script src="/js/img-swap.js"></script>
         <script src="/js/prism.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Removed MathJax.js from the article index.md file, as it didn't load correctly.

Also removed some white space at the ends of lines (emacs automatically does this for me).