### PR TITLE
List Filmulator as being for Windows too

### DIFF
--- a/src/software/index.md
+++ b/src/software/index.md
@@ -66,7 +66,7 @@ stylesheet: software-page
 	    </div>
         <div class="sw-entry filmulator">
             <a href="https://filmulator.org/">Filmulator</a>
-            <i class="fa fa-linux"></i>
+            <i class="fa fa-nix-win"></i>
             <p>
                 Streamlined raw management and editing application centered around a film-simulating
                 tone mapping algorithm.


### PR DESCRIPTION
Also, I've revised the icon recently.

I don't know how to replace them on the page, but I'll link them here:

https://github.com/CarVac/filmulator-gui/blob/master/filmulator-gui/resources/filmulator64icon.svg
https://github.com/CarVac/filmulator-gui/blob/master/filmulator-gui/resources/filmulator64icon.png